### PR TITLE
Add jupyterproxy upstream project

### DIFF
--- a/build/build-pnda.sh
+++ b/build/build-pnda.sh
@@ -62,6 +62,7 @@ declare -A bom=(
 #
 declare -A upstream=(
 [kafkamanager]=
+[jupyterproxy]=
 )
 
 function fill_bom {

--- a/build/docs/ADVANCED.md
+++ b/build/docs/ADVANCED.md
@@ -29,6 +29,7 @@ It is possible to use build-pnda.sh to build PNDA components & upstream projects
 |Upstream Projects|
 |---|
 |kafkamanager|
+|jupyterproxy|
 
 #### Examples
 
@@ -44,9 +45,10 @@ Simple BOM specifying a list of component versions and upstream project kafkaman
        platform-testing 0.1.0
        gobblin 0.1.0
        kafkamanager release/3.1
+       jupyterproxy release/3.1
 ```
 
-More complex BOM specifying various component versions, PNDA release versions and explicitly referencing a particular upstream version of the upstream project, kafkamanager.
+More complex BOM specifying various component versions, PNDA release versions and explicitly referencing particular upstream versions of the upstream projects.
 
 ```sh
        platform-console-backend 0.1.0
@@ -58,6 +60,7 @@ More complex BOM specifying various component versions, PNDA release versions an
        platform-testing develop
        gobblin 0.1.0
        kafkamanager UPSTREAM(1.3.2.4)
+       jupyterproxy UPSTREAM(1.3.1)
 ```
 
 Invocation example.

--- a/build/upstream-builds/build-jupyterproxy.sh
+++ b/build/upstream-builds/build-jupyterproxy.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# This script supports two use cases:
+#
+#   Build to specific PNDA version
+#       Pass "PNDA" as first parameter
+#       Pass platform-salt branch or tag as second parameter (e.g. release/3.2)
+#   Build specific upstream version
+#       Pass "UPSTREAM" as first parameter
+#       Pass upstream branch or tag as second parameter (e.g. 1.2.3.4)
+#
+
+MODE=${1}
+ARG=${2}
+
+function error {
+    echo "Not Found"
+    echo "Please run the build dependency installer script"
+    exit -1
+}
+
+echo -n "npm: "
+NPM_VERSION=$(npm --version 2>&1)
+if [[ ${NPM_VERSION} == "1.3"* ]] || [[ ${NPM_VERSION} == "3.5.2" ]] || [[ ${NPM_VERSION} == "3.10"* ]]; then
+    echo "OK"
+else
+    error
+fi
+
+echo -n "shyaml: "
+if [[ -z $(which shyaml) ]]; then
+    error
+else
+    echo "OK"
+fi
+
+if [[ ${MODE} == "PNDA" ]]; then
+    JP_VERSION=$(wget -qO- https://raw.githubusercontent.com/pndaproject/platform-salt/${ARG}/pillar/services.sls | shyaml get-value jupyterproxy.release_version)
+elif [[ ${MODE} == "UPSTREAM" ]]; then
+    JP_VERSION=${ARG}
+fi
+
+wget https://github.com/jupyterhub/configurable-http-proxy/archive/${JP_VERSION}.tar.gz
+tar xzf ${JP_VERSION}.tar.gz
+
+mkdir -p pnda-build
+cd configurable-http-proxy-${JP_VERSION}
+npm install
+cd ..
+tar zcf jupyterproxy-${JP_VERSION}.tar.gz configurable-http-proxy-${JP_VERSION}
+mv jupyterproxy-${JP_VERSION}.tar.gz pnda-build/
+sha512sum pnda-build/jupyterproxy-${JP_VERSION}.tar.gz > pnda-build/jupyterproxy-${JP_VERSION}.tar.gz.sha512.txt


### PR DESCRIPTION
This is required to cut dependency on online installation. Instead, we now handle this auxiliary application in the same way as we handle Kafka Manager.

PNDA-2691