### PR TITLE
Add specific mirror for nodejs

### DIFF
--- a/build/create_mirror.sh
+++ b/build/create_mirror.sh
@@ -35,18 +35,20 @@ if [ "x$DISTRO" == "xrhel" ]; then
     SALT_REPO=https://repo.saltstack.com/yum/redhat/7/x86_64/archive/2015.8.11
     SALT_REPO_KEY=https://repo.saltstack.com/yum/redhat/7/x86_64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub
     SALT_REPO_KEY2=http://repo.saltstack.com/yum/redhat/7/x86_64/2015.8/base/RPM-GPG-KEY-CentOS-7
+    NODE_REPO=https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 
     RPM_PACKAGE_LIST=$(<pnda-rpm-package-dependencies.txt)
 
     yum install -y $RPM_EPEL
     yum-config-manager --enable $RPM_EXTRAS $RPM_OPTIONAL
 
+    RPM_TMP=$(mktemp || bail)
+    curl -o ${RPM_TMP} ${NODE_REPO}
+    rpm -i --nosignature --force ${RPM_TMP}
+
     yum-config-manager --add-repo $MY_SQL_REPO
-    rpm --import $MY_SQL_REPO_KEY
     yum-config-manager --add-repo $CLOUDERA_MANAGER_REPO
-    rpm --import $CLOUDERA_MANAGER_REPO_KEY
     yum-config-manager --add-repo $SALT_REPO
-    rpm --import $SALT_REPO_KEY
 
     yum install -y createrepo
     rm -rf $RPM_REPO_DIR
@@ -58,6 +60,7 @@ if [ "x$DISTRO" == "xrhel" ]; then
     curl https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 > $RPM_REPO_DIR/RPM-GPG-KEY-EPEL-7
     curl $SALT_REPO_KEY > $RPM_REPO_DIR/SALTSTACK-GPG-KEY.pub
     curl $SALT_REPO_KEY2 > $RPM_REPO_DIR/RPM-GPG-KEY-CentOS-7
+    cp /etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL $RPM_REPO_DIR/NODESOURCE-GPG-SIGNING-KEY-EL
 
     #TODO yumdownloader doesn't always seem to download the full set of packages, for instance if git is installed, it won't download perl
     # packages correctly maybe because git already installed them. repotrack is meant to be better but I couldn't get that working.
@@ -80,6 +83,9 @@ EOF
     deb [arch=amd64] http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main
 EOF
     wget -O - 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add -
+
+    echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
+    wget -O - 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
 
     apt-get -y update
     apt-get -y install dpkg-dev debfoster rng-tools


### PR DESCRIPTION
PNDA-2691

Nodejs is at very old versions by default in the distros we use