### PR TITLE
Use npm in nodejs 6 for Ubuntu builds

### DIFF
--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -98,9 +98,12 @@ if [[ "${DISTRO}" == "rhel" ]]; then
                    python-setuptools \
                    python-devel \
                    python2-pip \                  
-                   libaio 
+                   libaio # Needed for Gobblin
 
 elif [[ "${DISTRO}" == "ubuntu" ]]; then
+
+    echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
+    curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
 
     apt-get update -y
     apt-get install -y python-dev \
@@ -108,7 +111,6 @@ elif [[ "${DISTRO}" == "ubuntu" ]]; then
                    gcc \
                    git \
                    nodejs \
-                   npm \
                    bc \
                    curl \
                    python-setuptools \


### PR DESCRIPTION
This enables the ability to build PNDA on the same node as the mirror is created, saving time/resources.

Previously, the build assumed a clean instance - which in the case of Ubuntu 14.04 means an old version of nodejs for which you need to install npm separately. This is no longer necessary in nodejs 6 and trying to force an install of npm fails if nodejs 6 (and therefore npm) is already installed.