### PR TITLE
Always export GPG key to deb mirror folder in update_mirror_deb.sh

### DIFF
--- a/mirror/tools/update_mirror_deb.sh
+++ b/mirror/tools/update_mirror_deb.sh
@@ -36,7 +36,8 @@ dpkg-scanpackages . /dev/null | tee Packages | gzip > Packages.gz
 # Expire-Date: 0
 # EOF
 # gpg --batch --gen-key ~/gpg_ops
-# gpg --output $DEB_REPO_DIR/pnda.gpg.key --armor --export info@pnda.io
+
+gpg --yes --output $DEB_REPO_DIR/pnda.gpg.key --armor --export info@pnda.io
 
 apt-ftparchive release . > Release
 gpg --yes --clearsign -o InRelease Release


### PR DESCRIPTION
If the key is not exported and the key in the folder came from another machine, i.e. the mirror files were generated elsewhere, then the key used to sign the packages as part of the update operation will not match the one available for clients to download. For this reason, always export the key used when updating the mirror.

PNDA-3078