### PR TITLE
Specify fixed version of sbt for RHEL

### DIFF
--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -136,7 +136,7 @@ echo "Dependency check: sbt"
 if [[ "${DISTRO}" == "rhel" ]]; then
 
     wget -qO- https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
-    sudo yum install sbt -y
+    sudo yum install sbt-0.13.9 -y
 
 elif [[ "${DISTRO}" == "ubuntu" ]]; then
 


### PR DESCRIPTION
This was previously floating to latest, which is now a problem for the kafka manager build which requires 0.13.x.

PNDA-3195