### PR TITLE
Fix openssl version at 1.0.1

### DIFF
--- a/mirror/dependencies/pnda-rpm-package-dependencies.txt
+++ b/mirror/dependencies/pnda-rpm-package-dependencies.txt
@@ -30,6 +30,8 @@ MySQL-python-1.2.5-1.el7
 nginx
 nmap-ncat
 ntp-4.2.6p5
+openssl-libs-1.0.1e-60.el7
+openssl-devel-1.0.1e-60.el7
 python2-pip
 python34-devel
 python34-pip


### PR DESCRIPTION
openssl 1.0.2 leaves ambari agents unable to connect to the server.

PNDA-3247