### PR TITLE
Uprev to logstash 5.2.2 and use prepare-offline-pack

### DIFF
--- a/mirror/create_mirror_misc.sh
+++ b/mirror/create_mirror_misc.sh
@@ -36,4 +36,5 @@ rm logstash-5.2.2.tar.gz
 cd logstash-5.2.2
 bin/logstash-plugin install $PLUGIN_LIST
 bin/logstash-plugin prepare-offline-pack $PLUGIN_LIST
+chmod a+r logstash-offline-plugins-5.2.2.zip
 mv logstash-offline-plugins-5.2.2.zip $STATIC_FILE_DIR/logstash-offline-plugins-5.2.2.zip

--- a/mirror/create_mirror_misc.sh
+++ b/mirror/create_mirror_misc.sh
@@ -30,10 +30,10 @@ elif [ "x$DISTRO" == "xubuntu" ]; then
 fi
 
 cd /tmp
-curl -LOJ https://artifacts.elastic.co/downloads/logstash/logstash-5.0.2.tar.gz
-tar zxf logstash-5.0.2.tar.gz
-rm logstash-5.0.2.tar.gz
-cd logstash-5.0.2
+curl -LOJ https://artifacts.elastic.co/downloads/logstash/logstash-5.2.2.tar.gz
+tar zxf logstash-5.2.2.tar.gz
+rm logstash-5.2.2.tar.gz
+cd logstash-5.2.2
 bin/logstash-plugin install $PLUGIN_LIST
-bin/logstash-plugin pack
-mv plugins_package.tar.gz $STATIC_FILE_DIR/logstash_plugins.tar.gz
+bin/logstash-plugin prepare-offline-pack $PLUGIN_LIST
+mv logstash-offline-plugins-5.2.2.zip $STATIC_FILE_DIR/logstash-offline-plugins-5.2.2.zip

--- a/mirror/dependencies/pnda-static-file-dependencies.txt
+++ b/mirror/dependencies/pnda-static-file-dependencies.txt
@@ -5,8 +5,8 @@ http://www.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz.sha1
 http://www.mirrorservice.org/sites/ftp.apache.org/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz
 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz
 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz.sha1
-https://artifacts.elastic.co/downloads/logstash/logstash-5.0.2.tar.gz
-https://artifacts.elastic.co/downloads/logstash/logstash-5.0.2.tar.gz.sha1
+https://artifacts.elastic.co/downloads/logstash/logstash-5.2.2.tar.gz
+https://artifacts.elastic.co/downloads/logstash/logstash-5.2.2.tar.gz.sha1
 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.0.tar.gz
 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.0.tar.gz.sha1.txt
 https://download.elastic.co/kibana/kibana/kibana-4.1.6-linux-x64.tar.gz


### PR DESCRIPTION
This resolves known issues with logstash-plugin install --local still trying to connect to Rubygems.
