### PR TITLE
Adding dependency gems for kafka-tool for offline installation

### DIFF
--- a/build/upstream-builds/build-kafkatool.sh
+++ b/build/upstream-builds/build-kafkatool.sh
@@ -33,7 +33,6 @@ elif [[ ${MODE} == "UPSTREAM" ]]; then
 fi
 
 echo `pwd`
-CUR_DIR=${PWD}
 git clone https://github.com/airbnb/kafkat.git
 mkdir -p pnda-build
 mv kafkat kafka-tool-${KT_VERSION}
@@ -42,7 +41,7 @@ git checkout tags/${KT_VERSION}
 gem build kafkat.gemspec
 mv kafkat*.gem kafkat-${KT_VERSION}.gem
 #Download all kafkat gem dependency gems
-GEM_LIST=$(<${CUR_DIR}/../../upstream-builds/dependencies/upstream-kafka-tool-dependencies.txt)
+GEM_LIST=$(<../../../upstream-builds/dependencies/upstream-kafka-tool-dependencies.txt)
 for gem in $GEM_LIST ; do
     wget https://rubygems.org/downloads/${gem}
 done

--- a/build/upstream-builds/build-kafkatool.sh
+++ b/build/upstream-builds/build-kafkatool.sh
@@ -33,6 +33,7 @@ elif [[ ${MODE} == "UPSTREAM" ]]; then
 fi
 
 echo `pwd`
+CUR_DIR=${PWD}
 git clone https://github.com/airbnb/kafkat.git
 mkdir -p pnda-build
 mv kafkat kafka-tool-${KT_VERSION}
@@ -40,6 +41,11 @@ cd kafka-tool-${KT_VERSION}
 git checkout tags/${KT_VERSION}
 gem build kafkat.gemspec
 mv kafkat*.gem kafkat-${KT_VERSION}.gem
+#Download all kafkat gem dependency gems
+GEM_LIST=$(<${CUR_DIR}/../../upstream-builds/dependencies/upstream-kafka-tool-dependencies.txt)
+for gem in $GEM_LIST ; do
+    wget https://rubygems.org/downloads/${gem}
+done
 cd ..
 tar czf kafka-tool-${KT_VERSION}.tar.gz kafka-tool-${KT_VERSION}
 mv kafka-tool-${KT_VERSION}.tar.gz pnda-build/

--- a/build/upstream-builds/dependencies/upstream-kafka-tool-dependencies.txt
+++ b/build/upstream-builds/dependencies/upstream-kafka-tool-dependencies.txt
@@ -1,0 +1,7 @@
+colored-1.2.gem
+highline-1.7.8.gem
+json-1.8.6.gem
+retryable-1.3.6.gem
+trollop-2.1.2.gem
+zookeeper-1.4.11.gem
+zk-1.9.6.gem


### PR DESCRIPTION
Problem Statement:
    kafka-tool errored during offline installation

Analysis:
    Kafkat-requires run time dependency gems which are, colored-1.2.gem, highline-1.7.8.gem, json-1.8.6.gem, retryable-1.3.6.gem, trollop-2.1.2.gem, zookeeper-1.4.11.gem, zk-1.9.6.gem
    
Change:
    Created dependency file upstream-kafka-tool-dependencies.txt under build/upstream-builds/dependencies/
    Added code in build-kafkatool.sh to wget the required gems using upstream-kafka-tool-dependencies.txt in the kafka-tool directory 
    
Test details:
    Test1 -  created build based on develop branch and verified the gems, which all are available.
    Test2 -  installation manually, using the kafkat.gem, by shutdown all the interfaces, so that, no reachability for internet using openstack instance web ui console.
    Test3 -  offiline test in openstack pico ubuntu in openstack.