### PR TITLE
Explicit ERROR on problem during creation

### DIFF
--- a/mirror/create_mirror.sh
+++ b/mirror/create_mirror.sh
@@ -4,6 +4,11 @@ export DISTRO=$(cat /etc/*-release|grep ^ID\=|awk -F\= {'print $2'}|sed s/\"//g)
 [[ -z ${MIRROR_BUILD_DIR} ]] && export MIRROR_BUILD_DIR=${PWD}
 [[ -z ${MIRROR_OUTPUT_DIR} ]] && export MIRROR_OUTPUT_DIR=${PWD}/mirror-dist
 
+function mirror_error {
+    echo "ERROR: $1"
+    exit -1
+}
+
 if [ "x$DISTRO" == "xrhel" ]; then
 	echo "Use of Red Hat software is governed by your agreement with Red Hat."
 	echo "In order to proceed, you must have a valid Red Hat subscription and software image on your system."
@@ -19,8 +24,19 @@ elif [ "x$DISTRO" == "xubuntu" ]; then
     $MIRROR_BUILD_DIR/create_mirror_deb.sh
 fi
 
+[[ $? -ne 0 ]] && mirror_error "Problem while creating os package mirror"
+
 $MIRROR_BUILD_DIR/create_mirror_misc.sh
+[[ $? -ne 0 ]] && mirror_error "Problem while creating misc package mirror"
+
 $MIRROR_BUILD_DIR/create_mirror_cdh.sh
+[[ $? -ne 0 ]] && mirror_error "Problem while creating cdh package mirror"
+
 $MIRROR_BUILD_DIR/create_mirror_anaconda.sh
+[[ $? -ne 0 ]] && mirror_error "Problem while creating anaconda package mirror"
+
 $MIRROR_BUILD_DIR/create_mirror_hdp.sh
+[[ $? -ne 0 ]] && mirror_error "Problem while creating hdp package mirror"
+
 $MIRROR_BUILD_DIR/create_mirror_python.sh
+[[ $? -ne 0 ]] && mirror_error "Problem while creating python package mirror"


### PR DESCRIPTION
While mirrors exit early on problems, there's little consistency in the way
errors are reported by the underlying technologies. This ensures that 
there is at least one consistent message for ease of problem diagnosis.