### PR TITLE
Fix return code in 'create_mirror.sh'.

### DIFF
--- a/mirror/create_mirror.sh
+++ b/mirror/create_mirror.sh
@@ -40,3 +40,5 @@ $MIRROR_BUILD_DIR/create_mirror_hdp.sh
 
 $MIRROR_BUILD_DIR/create_mirror_python.sh
 [[ $? -ne 0 ]] && mirror_error "Problem while creating python package mirror"
+
+exit 0


### PR DESCRIPTION
To avoid returning the last comparison, which should under successful
circumstances
  [[ 0 -ne 0 ]]
evaluate to 1,
an explicit exit 0 needs to be added at the end of the script.