### PR TITLE
PNDA-2832: Jupyter %sql magic support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - PNDA-3562: add pam-devel for PAM authentication on PNDA console frontend
+- PNDA-2832: Jupyter %sql magic support
 
 ### Changed
 - PNDA-3579: ignore files generated on install build tools step

--- a/mirror/create_mirror_misc.sh
+++ b/mirror/create_mirror_misc.sh
@@ -25,8 +25,10 @@ sha512sum Anaconda2-4.0.0-Linux-x86_64.sh > Anaconda2-4.0.0-Linux-x86_64.sh.sha5
 
 if [ "x$DISTRO" == "xrhel" -o "x$DISTRO" == "xcentos" ]; then
     yum install -y java-1.7.0-openjdk
+    yum install -y postgresql-devel
 elif [ "x$DISTRO" == "xubuntu" ]; then
     apt-get install -y default-jre
+    apt-get install -y libpq-dev
 fi
 
 cd /tmp

--- a/mirror/dependencies/pnda-deb-package-dependencies.txt
+++ b/mirror/dependencies/pnda-deb-package-dependencies.txt
@@ -19,6 +19,7 @@ libffi-dev
 libkrb5-dev
 libmysql-java=5.1.28-1
 libpam0g-dev
+libpq-dev
 libsasl2-dev
 libsodium13
 libxml2-dev

--- a/mirror/dependencies/pnda-rpm-package-dependencies-centos.txt
+++ b/mirror/dependencies/pnda-rpm-package-dependencies-centos.txt
@@ -41,6 +41,7 @@ openssl-libs-1.0.2k-8.el7
 openssl-devel-1.0.2k-8.el7
 pam-devel
 policycoreutils-python
+postgresql-devel
 python-carbon
 python-chardet
 python-devel

--- a/mirror/dependencies/pnda-rpm-package-dependencies-rhel.txt
+++ b/mirror/dependencies/pnda-rpm-package-dependencies-rhel.txt
@@ -41,6 +41,7 @@ openssl-1.0.2k-8.el7
 openssl-libs-1.0.2k-8.el7
 openssl-devel-1.0.2k-8.el7
 policycoreutils-python
+postgresql-devel
 python-carbon
 python-chardet
 python-devel

--- a/mirror/dependencies/pnda_requirements_py2.txt
+++ b/mirror/dependencies/pnda_requirements_py2.txt
@@ -76,6 +76,7 @@ ply==3.9
 positional==1.1.1
 prettytable==0.7.2
 prompt_toolkit==1.0.15
+psycopg2==2.7.3.2
 ptyprocess==0.5.1
 pyasn1==0.1.9
 pycparser==2.17
@@ -83,6 +84,7 @@ pyhive==0.2.1
 pyhs2==0.6.0
 pykerberos==1.1.14
 pyparsing==2.1.10
+pymysql==0.7.11
 python-keystoneclient==3.8.0
 python-swiftclient==3.2.0
 pytz==2016.10

--- a/mirror/dependencies/pnda_requirements_py3.txt
+++ b/mirror/dependencies/pnda_requirements_py3.txt
@@ -8,6 +8,7 @@ entrypoints==0.2.2
 hdijupyterutils==0.12.4
 html5lib==0.9999999
 https://github.com/klyr/jupyter-spark/releases/download/0.3.0-patch/jupyter-spark-0.3.0-patch.tar.gz
+impyla==0.14.0
 ipykernel==4.5.2
 ipython-genutils==0.1.0
 ipython==5.1.0
@@ -37,9 +38,11 @@ pexpect==4.2.1
 pickleshare==0.7.4
 plotly==1.10.0
 prompt-toolkit==1.0.9
+psycopg2==2.7.3.2
 ptyprocess==0.5.1
 Pygments==2.1.3
 pykerberos==1.1.14
+pymysql==0.7.11
 python_dateutil==2.6.0
 python-editor==1.0.3
 pyzmq==16.0.2
@@ -53,6 +56,7 @@ SQLAlchemy==1.1.4
 sql-magic==0.0.3
 terminado==0.6
 testpath==0.3
+thrift==0.9.3
 tornado==4.4.2
 traitlets==4.3.1
 wcwidth==0.1.7


### PR DESCRIPTION
# Problem Statement:
PNDA-2832: Jupyter %sql magic support.

# Analysis:
The Jupyter notebook should be able to support the sql-magic extension along with other extensions.

# Change:
pnda - Added the sql-magic extension support related packages to the mirror repository.
platform-salt - Install the sql-magic extension support related packges to the kernel supporting virtual environments.

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD  -CDH & HDP
RHEL   - PICO -CDH & HDP
RHEL   - STD  -CDH & HDP
Verification pending for OpenStack
