### PR TITLE
PNDA-3133: Remove Gobblin fork and use release distribution instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3562: add pam-devel for PAM authentication on PNDA console frontend
 - PNDA-2832: Jupyter %sql magic support
 - PNDA-1899: Scala Spark Jupyter Integration
+- PNDA-3133: Remove Gobblin fork and use release distribution instead.
 
 ### Changed
 - PNDA-3579: ignore files generated on install build tools step

--- a/build/build-pnda.sh
+++ b/build/build-pnda.sh
@@ -68,7 +68,6 @@ declare -A bom=(
 [platform-libraries]=
 [platform-package-repository]=
 [platform-testing]=
-[gobblin]=
 )
 
 # List of upstream projects
@@ -78,6 +77,7 @@ declare -A upstream=(
 [jupyterproxy]=
 [kafkatool]=
 [livy]=
+[gobblin]=
 )
 
 function fill_bom {

--- a/build/docs/ADVANCED.md
+++ b/build/docs/ADVANCED.md
@@ -24,13 +24,13 @@ It is possible to use build-pnda.sh to build PNDA components & upstream projects
 |platform-libraries|
 |platform-package-repository| 
 |platform-testing| 
-|gobblin| 
        
 |Upstream Projects|
 |---|
 |kafkamanager|
 |jupyterproxy|
 |livy|
+|gobblin| 
 
 #### Examples
 
@@ -63,6 +63,7 @@ More complex BOM specifying various component versions, PNDA release versions an
        kafkamanager UPSTREAM(1.3.2.4)
        jupyterproxy UPSTREAM(1.3.1)
        livy UPSTREAM(0.3.0)
+       gobblin UPSTREAM(0.11.0)
 ```
 
 Invocation example.

--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -107,6 +107,7 @@ if [ "x${DISTRO}" == "xrhel" -o "x$DISTRO" == "xcentos" ]; then
                    python-devel \
                    python2-pip \
                    ruby-devel \
+                   unzip \
                    libaio # Needed for Gobblin
 
 elif [[ "${DISTRO}" == "ubuntu" ]]; then
@@ -127,6 +128,7 @@ elif [[ "${DISTRO}" == "ubuntu" ]]; then
                    libpam0g-dev \
                    python-pip \
                    ruby-dev \
+                   unzip \
                    libaio1 # Needed for Gobblin
 fi
 

--- a/build/upstream-builds/build-gobblin.sh
+++ b/build/upstream-builds/build-gobblin.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# This script supports:
+#
+#   Build to specific PNDA version
+#       Pass "PNDA" as first parameter
+#       Pass platform-salt branch or tag as second parameter (e.g. release/3.2)
+#   Build specific upstream version
+#       Pass "UPSTREAM" as first parameter
+#       Pass upstream branch or tag as second parameter (e.g. 1.2.3.4)
+#   Here,
+#       We clone the entire apache gobblin-incubator repository.
+#       Add the gobblin-PNDA classes from dependency classes in the apache gobblin as a module.
+#       Build the gobblin-PNDA jar along with other dependencies from the apache.
+
+MODE=${1}
+ARG=${2}
+
+EXCLUDES="-x test"
+set -e
+set -x
+
+export LC_ALL=en_US.utf8
+HADOOP_VERSION=2.6.0-cdh5.9.0
+
+function error {
+    echo "Not Found"
+    echo "Please run the build dependency installer script"
+    exit -1
+}
+
+echo -n "Java 1.8: "
+if [[ $($JAVA_HOME/bin/javac -version 2>&1) != "javac 1.8"* ]]; then
+    error
+else
+    echo "OK"
+fi
+
+echo -n "shyaml: "
+if [[ -z $(which shyaml) ]]; then
+    error
+else
+    echo "OK"
+fi
+
+
+if [[ ${MODE} == "PNDA" ]]; then
+    GB_VERSION=$(wget -qO- https://raw.githubusercontent.com/pndaproject/platform-salt/${ARG}/pillar/services.sls | shyaml get-value gobblin.release_version)
+
+elif [[ ${MODE} == "UPSTREAM" ]]; then
+    GB_VERSION=${ARG}
+fi
+
+# Download the upstream and pnda-gobblin repository
+git clone https://github.com/pndaproject/platform-gobblin-modules.git
+wget https://github.com/apache/incubator-gobblin/archive/gobblin_${GB_VERSION}.tar.gz
+tar xzf gobblin_${GB_VERSION}.tar.gz
+
+# Build upstream gobblin
+mkdir -p pnda-build
+
+cd incubator-gobblin-gobblin_${GB_VERSION}
+if ! fgrep -q 'tasks.withType(Javadoc).all { enabled = false }' build.gradle; then
+cat >> build.gradle << EOF
+subprojects {
+  tasks.withType(Javadoc).all { enabled = false }
+}
+EOF
+fi
+
+./gradlew build -Pversion="${GB_VERSION}" -PhadoopVersion="${HADOOP_VERSION}" -PexcludeHadoopDeps -PexcludeHiveDeps ${EXCLUDES}
+mv gobblin-distribution-${GB_VERSION}.tar.gz ../platform-gobblin-modules/
+
+# Build PNDA gobblin modules
+cd ../platform-gobblin-modules
+tar xvf gobblin-distribution-${GB_VERSION}.tar.gz
+rm gobblin-distribution-${GB_VERSION}.tar.gz
+./gradlew build -Pversion="${GB_VERSION}"
+cp -rvf ./build/libs/* ./gobblin-dist/lib/
+rm -rf ./build/libs/*
+tar -cvf gobblin-distribution-${GB_VERSION}.tar.gz ./gobblin-dist
+mv gobblin-distribution-${GB_VERSION}.tar.gz ../pnda-build/
+cd ..
+sha512sum pnda-build/gobblin-distribution-${GB_VERSION}.tar.gz > pnda-build/gobblin-distribution-${GB_VERSION}.tar.gz.sha512.txt
+


### PR DESCRIPTION
# Problem Statement:
PNDA-3133: Remove Gobblin fork and use release distribution instead.

# Analysis:
- Currenlty, gobblin is not a upstream project.
- We need to build the gobblin components as upstream components except the pnda-gobblin.

# Change:
- Changed the gobblin as a upsteam build project.
- Added the gobblin build script which builds gobblin as upstream project and uses the built jars as jar dependeny to build pnda-gobblin.


# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification pending for OpenStack.