### PR TITLE
PNDA-3128: Add kafka-python new version and avro-python in app-packages

### DIFF
--- a/mirror/create_mirror.sh
+++ b/mirror/create_mirror.sh
@@ -44,4 +44,7 @@ $MIRROR_BUILD_DIR/create_mirror_hdp.sh
 $MIRROR_BUILD_DIR/create_mirror_python.sh
 [[ $? -ne 0 ]] && mirror_error "Problem while creating python package mirror"
 
+$MIRROR_BUILD_DIR/create_mirror_apps.sh
+[[ $? -ne 0 ]] && mirror_error "Problem while creating app package mirror"
+
 exit 0

--- a/mirror/create_mirror_apps.sh
+++ b/mirror/create_mirror_apps.sh
@@ -1,0 +1,23 @@
+[[ -z ${MIRROR_OUTPUT_DIR} ]] && export MIRROR_OUTPUT_DIR=${PWD}/mirror-dist
+STATIC_FILE_DIR=$MIRROR_OUTPUT_DIR/mirror_apps
+mkdir -p $STATIC_FILE_DIR
+cd $STATIC_FILE_DIR
+cp $MIRROR_OUTPUT_DIR/mirror_python/packages/kafka-python-1.3.5.tar.gz ./
+[[ $? -ne 0 ]] && echo "Error copying kafka-python" && exit -1
+cp $MIRROR_OUTPUT_DIR/mirror_python/packages/avro-1.8.1.tar.gz ./
+[[ $? -ne 0 ]] && echo "Error copying avro-python" && exit -1
+CANDIDATES=(`ls $STATIC_FILE_DIR/*`)
+for c in ${CANDIDATES[*]}
+do
+    tar zxf $c
+    [[ $? -ne 0 ]] && echo "Error extracting ${c}" && exit -1
+    rm -rf $c
+    filename="${c/%.tar.gz/}"
+    cd "$filename"
+    python setup.py bdist_egg
+    [[ $? -ne 0 ]] && echo "Error creating egg file for ${c}" && exit -1
+    egg_file=(`ls dist/*.egg`)
+    cp $egg_file .././
+    rm -rf "$filename"
+    cd ..
+done

--- a/mirror/dependencies/pnda_requirements_py2.txt
+++ b/mirror/dependencies/pnda_requirements_py2.txt
@@ -49,6 +49,7 @@ iso8601==0.1.11
 itsdangerous==0.24
 jsonschema==2.5.1
 kafka-python==0.9.5
+kafka-python==1.3.5
 kazoo==2.2.1
 keystoneauth1==2.16.0
 lxml==3.6.4


### PR DESCRIPTION
Understanding the Requirements:
PNDA-3128: Add kafka-python (new version) and avro python packages to app-packages.

Analysis
Currently kafka-python and avro-python egg files are not there in mirror. These egg files should be in /mirror_apps directory in mirror to stage into HDFS.
 
Solution
1. Created /mirror_apps directory in pnda mirror as this is the directory used in platform-salt/salt/app-packages/templates/sync.sh.tpl to stage the egg files into HDFS
2. Copied kafka-python and avro-python tar files from /mirror_python/packages into /mirror_apps directory
3. Built egg files for kafka-python and avro-python tar files.

File modified
pnda/mirror/create_mirror.sh
pnda/mirror/create_mirror_apps.sh

Testcase
UBUNTU : Created PNDA mirror and used this mirror to deploy the cluster
RHEL   : Created PNDA mirror and used this mirror to deploy the cluster