### PR TITLE
Release 3.6 test status update for Openstack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3249: Upgrade Kafka version to 0.11.0.0
 - PNDA-2884: Upgrade CDH and Cloudera Manager version 5.12.1
 - PNDA-3530: Ambari version 2.6.0.0 and HDP version 2.6.3.0
+- PNDA-3483: Zookeeper version 3.4.11
 
 ### Fixed
 - PNDA-3499: Cleanup CHANGELOG with missing release info.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3289: Detect errors when building mirror and set exit code
 - PNDA-3249: Upgrade Kafka version to 0.11.0.0
 - PNDA-2884: Upgrade CDH and Cloudera Manager version 5.12.1
+- PNDA-3530: Ambari version 2.6.0.0 and HDP version 2.6.3.0
 
 ### Fixed
 - PNDA-3499: Cleanup CHANGELOG with missing release info.

--- a/mirror/create_mirror_deb.sh
+++ b/mirror/create_mirror_deb.sh
@@ -15,7 +15,7 @@ curl -L 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | 
 echo 'deb [arch=amd64] http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
 curl -L 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add -
 
-echo 'deb http://public-repo-1.hortonworks.com/ambari/ubuntu14/2.x/updates/2.5.1.0 Ambari main' > /etc/apt/sources.list.d/ambari.list
+echo 'deb http://public-repo-1.hortonworks.com/ambari/ubuntu14/2.x/updates/2.6.0.0 Ambari main' > /etc/apt/sources.list.d/ambari.list
 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com B9733A7A07513CAD
 
 apt-get -y update

--- a/mirror/create_mirror_hdp.sh
+++ b/mirror/create_mirror_hdp.sh
@@ -33,8 +33,11 @@ do
     fi
 done
 
-tar zxf HDP-2.6.0.3-centos7-rpm.tar.gz
-tar zxf HDP-2.6.0.3-ubuntu14-deb.tar.gz
+apt-key adv --recv-keys --keyserver keyserver.ubuntu.com B9733A7A07513CAD
+apt-key export 'Jenkins (HDP Builds) <jenkin@hortonworks.com>' > hdp.gpg.key
+
+tar zxf HDP-2.6.3.0-centos7-rpm.tar.gz
+tar zxf HDP-2.6.3.0-ubuntu14-deb.tar.gz
 mkdir -p HDP-UTILS-1.1.0.21/repos/ubuntu14/
 tar zxf HDP-UTILS-1.1.0.21-ubuntu14.tar.gz -C 'HDP-UTILS-1.1.0.21/repos/ubuntu14/'
 mkdir -p HDP-UTILS-1.1.0.21/repos/centos7/

--- a/mirror/create_mirror_hdp.sh
+++ b/mirror/create_mirror_hdp.sh
@@ -33,8 +33,10 @@ do
     fi
 done
 
-apt-key adv --recv-keys --keyserver keyserver.ubuntu.com B9733A7A07513CAD
-apt-key export 'Jenkins (HDP Builds) <jenkin@hortonworks.com>' > hdp.gpg.key
+if [ "x$DISTRO" == "xubuntu" ]; then
+    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com B9733A7A07513CAD
+    apt-key export 'Jenkins (HDP Builds) <jenkin@hortonworks.com>' > hdp.gpg.key
+fi
 
 tar zxf HDP-2.6.3.0-centos7-rpm.tar.gz
 tar zxf HDP-2.6.3.0-ubuntu14-deb.tar.gz

--- a/mirror/create_mirror_hdp.sh
+++ b/mirror/create_mirror_hdp.sh
@@ -40,7 +40,11 @@ fi
 
 tar zxf HDP-2.6.3.0-centos7-rpm.tar.gz
 tar zxf HDP-2.6.3.0-ubuntu14-deb.tar.gz
+
 mkdir -p HDP-UTILS-1.1.0.21/repos/ubuntu14/
 tar zxf HDP-UTILS-1.1.0.21-ubuntu14.tar.gz -C 'HDP-UTILS-1.1.0.21/repos/ubuntu14/'
 mkdir -p HDP-UTILS-1.1.0.21/repos/centos7/
 tar zxf HDP-UTILS-1.1.0.21-centos7.tar.gz -C 'HDP-UTILS-1.1.0.21/repos/centos7/'
+
+rm -f HDP-2.6.3.0-centos7-rpm.tar.gz
+rm -f HDP-2.6.3.0-ubuntu14-deb.tar.gz

--- a/mirror/create_mirror_rpm.sh
+++ b/mirror/create_mirror_rpm.sh
@@ -17,7 +17,7 @@ CLOUDERA_MANAGER_REPO_KEY=https://archive.cloudera.com/cm5/redhat/7/x86_64/cm/RP
 SALT_REPO=https://repo.saltstack.com/yum/redhat/7/x86_64/archive/2015.8.11
 SALT_REPO_KEY=https://repo.saltstack.com/yum/redhat/7/x86_64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub
 SALT_REPO_KEY2=http://repo.saltstack.com/yum/redhat/7/x86_64/2015.8/base/RPM-GPG-KEY-CentOS-7
-AMBARI_REPO=http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.5.1.0/ambari.repo
+AMBARI_REPO=http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.6.0.0/ambari.repo
 AMBARI_REPO_KEY=http://public-repo-1.hortonworks.com/ambari/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
 
 yum install -y $RPM_EPEL || true

--- a/mirror/dependencies/pnda-deb-package-dependencies.txt
+++ b/mirror/dependencies/pnda-deb-package-dependencies.txt
@@ -1,7 +1,7 @@
 acl
-ambari-agent=2.5.1.0-159
-ambari-metrics-assembly=2.5.1.0-159
-ambari-server=2.5.1.0-159
+ambari-agent=2.6.0.0-267
+ambari-metrics-assembly=2.6.0.0-267
+ambari-server=2.6.0.0-267
 build-essential
 cloudera-manager-agent=5.12.1-1.cm5121.p0.6~trusty-cm5
 cloudera-manager-daemons=5.12.1-1.cm5121.p0.6~trusty-cm5

--- a/mirror/dependencies/pnda-hdp-resources.txt
+++ b/mirror/dependencies/pnda-hdp-resources.txt
@@ -1,4 +1,4 @@
-http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.0.3/HDP-2.6.0.3-centos7-rpm.tar.gz
+http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.3.0/HDP-2.6.3.0-centos7-rpm.tar.gz
 http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos7/HDP-UTILS-1.1.0.21-centos7.tar.gz
-http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.6.0.3/HDP-2.6.0.3-ubuntu14-deb.tar.gz
+http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.6.3.0/HDP-2.6.3.0-ubuntu14-deb.tar.gz
 http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu14/HDP-UTILS-1.1.0.21-ubuntu14.tar.gz

--- a/mirror/dependencies/pnda-rpm-package-dependencies-centos.txt
+++ b/mirror/dependencies/pnda-rpm-package-dependencies-centos.txt
@@ -1,10 +1,10 @@
 MySQL-python-1.2.5-1.el7
 acl
-ambari-agent-2.5.1.0-159
-ambari-metrics-collector-2.5.1.0-159
-ambari-metrics-hadoop-sink-2.5.1.0-159
-ambari-metrics-monitor-2.5.1.0-159
-ambari-server-2.5.1.0-159
+ambari-agent-2.6.0.0-267
+ambari-metrics-collector-2.6.0.0-267
+ambari-metrics-hadoop-sink-2.6.0.0-267
+ambari-metrics-monitor-2.6.0.0-267
+ambari-server-2.6.0.0-267
 apr
 apr-util
 at

--- a/mirror/dependencies/pnda-rpm-package-dependencies-rhel.txt
+++ b/mirror/dependencies/pnda-rpm-package-dependencies-rhel.txt
@@ -1,10 +1,10 @@
 MySQL-python-1.2.5-1.el7
 acl
-ambari-agent-2.5.1.0-159
-ambari-metrics-collector-2.5.1.0-159
-ambari-metrics-hadoop-sink-2.5.1.0-159
-ambari-metrics-monitor-2.5.1.0-159
-ambari-server-2.5.1.0-159
+ambari-agent-2.6.0.0-267
+ambari-metrics-collector-2.6.0.0-267
+ambari-metrics-hadoop-sink-2.6.0.0-267
+ambari-metrics-monitor-2.6.0.0-267
+ambari-server-2.6.0.0-267
 apr
 apr-util
 at

--- a/mirror/dependencies/pnda-static-file-dependencies.txt
+++ b/mirror/dependencies/pnda-static-file-dependencies.txt
@@ -20,8 +20,7 @@ https://nodejs.org/download/release/v6.10.2/SHASUMS256.txt
 https://nodejs.org/download/release/v6.10.2/node-v6.10.2-linux-x64.tar.gz
 https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.2.0-1.x86_64.rpm
 https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.2.0_amd64.deb
-http://search.maven.org/remotecontent?filepath=com/sleepycat/je/5.0.73/je-5.0.73.jar
+http://central.maven.org/maven2/com/sleepycat/je/5.0.73/je-5.0.73.jar
 https://repo.continuum.io/archive/Anaconda2-4.0.0-Linux-x86_64.sh
 http://central.maven.org/maven2/org/kitesdk/kite-tools/1.0.0/kite-tools-1.0.0-binary.jar
 http://central.maven.org/maven2/org/kitesdk/kite-tools/1.0.0/kite-tools-1.0.0-binary.jar.sha1
-

--- a/mirror/dependencies/pnda-static-file-dependencies.txt
+++ b/mirror/dependencies/pnda-static-file-dependencies.txt
@@ -1,7 +1,7 @@
 -b oraclelicense=accept-securebackup-cookie -L http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
 http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.25/mysql-connector-java-5.1.25.jar
-http://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
-http://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz.sha1
+http://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
+http://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz.sha1
 http://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz
 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz
 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz.sha1

--- a/releases/release-note-3.6.md
+++ b/releases/release-note-3.6.md
@@ -76,13 +76,13 @@ For more details refer to the [Hadoop Distributions](https://github.com/pndaproj
 |RHEL, CDH|PASSED|PASSED|
 |Ubuntu, CDH|PASSED|PASSED|
 
-#### Using the ```heat-cli``` on *OpenStack*
+#### Using the ```heat-cli``` on *OpenStack* 
 ||pico|standard|
 |---|---|---|
-|RHEL, HDP|pending|pending|
-|Ubuntu, HDP|pending|pending|
-|RHEL, CDH|pending|pending|
-|Ubuntu, CDH|pending|pending|
+|RHEL, HDP|PASSED|PASSED|
+|Ubuntu, HDP|PASSED|PASSED|
+|RHEL, CDH|PASSED|PASSED|
+|Ubuntu, CDH|PASSED|PASSED|
 
 ### Change Log
  


### PR DESCRIPTION
PNDA release 3.6 online tested in openstack for the below mentioned tests, with the workaround for issue https://github.com/pndaproject/platform-salt/issues/344 and with PR -  https://github.com/pndaproject/pnda-heat-templates/pull/140 

TESTS:

Ubuntu-CDH - PICO - PASSED
Ubuntu-HDP - PICO - PASSED
Ubuntu-CDH - STD - PASSED
Ubuntu-HDP- STD - PASSED
RHEL-CDH - PICO - PASSED
RHEL-HDP - PICO - PASSED
RHEL-CDH - STD - PASSED
RHEL-HDP- STD - PASSED