### PR TITLE
Adding openstack test status

### DIFF
--- a/releases/release-note-3.6.md
+++ b/releases/release-note-3.6.md
@@ -79,10 +79,10 @@ For more details refer to the [Hadoop Distributions](https://github.com/pndaproj
 #### Using the ```heat-cli``` on *OpenStack*
 ||pico|standard|
 |---|---|---|
-|RHEL, HDP|pending|pending|
-|Ubuntu, HDP|pending|pending|
-|RHEL, CDH|pending|pending|
-|Ubuntu, CDH|pending|pending|
+|RHEL, HDP|PASSED|PASSED|
+|Ubuntu, HDP|PASSED|PASSED|
+|RHEL, CDH|PASSED|PASSED|
+|Ubuntu, CDH|PASSED|PASSED|
 
 ### Change Log
  


### PR DESCRIPTION
PNDA release 3.6 online tested in openstack for the below mentioned tests, with the workaround for issue pndaproject/platform-salt#344.

TESTS:

Ubuntu-CDH - PICO - PASSED
Ubuntu-HDP - PICO - PASSED
Ubuntu-CDH - STD - PASSED
Ubuntu-HDP- STD - PASSED
RHEL-CDH - PICO - PASSED
RHEL-HDP - PICO - PASSED
RHEL-CDH - STD - PASSED
RHEL-HDP- STD - PASSED