### PR TITLE
PNDA-3133: Remove Gobblin fork and use release distribution instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3562: add pam-devel for PAM authentication on PNDA console frontend
 - PNDA-2832: Jupyter %sql magic support
 - PNDA-1899: Scala Spark Jupyter Integration
+- PNDA-3133: Remove Gobblin fork and use release distribution instead.
 
 ### Changed
 - PNDA-3579: ignore files generated on install build tools step

--- a/build/build-pnda.sh
+++ b/build/build-pnda.sh
@@ -68,7 +68,7 @@ declare -A bom=(
 [platform-libraries]=
 [platform-package-repository]=
 [platform-testing]=
-[gobblin]=
+[platform-gobblin-modules]=
 )
 
 # List of upstream projects
@@ -78,6 +78,7 @@ declare -A upstream=(
 [jupyterproxy]=
 [kafkatool]=
 [livy]=
+[gobblin]=
 )
 
 function fill_bom {
@@ -185,3 +186,4 @@ do
 done
 
 cd ${BASE}
+

--- a/build/docs/ADVANCED.md
+++ b/build/docs/ADVANCED.md
@@ -23,14 +23,15 @@ It is possible to use build-pnda.sh to build PNDA components & upstream projects
 |platform-deployment-manager|
 |platform-libraries|
 |platform-package-repository| 
-|platform-testing| 
-|gobblin| 
+|platform-testing|  
+|platform-gobblin-modules|
        
 |Upstream Projects|
 |---|
 |kafkamanager|
 |jupyterproxy|
 |livy|
+|gobblin|
 
 #### Examples
 
@@ -59,10 +60,10 @@ More complex BOM specifying various component versions, PNDA release versions an
        platform-libraries develop
        platform-package-repository 0.1.2
        platform-testing develop
-       gobblin 0.1.0
        kafkamanager UPSTREAM(1.3.2.4)
        jupyterproxy UPSTREAM(1.3.1)
        livy UPSTREAM(0.3.0)
+       gobblin UPSTREAM(0.11.0)
 ```
 
 Invocation example.
@@ -71,3 +72,4 @@ Invocation example.
 cd pnda
 ./build-pnda.sh BOM bomfile
 ```
+

--- a/build/upstream-builds/build-gobblin.sh
+++ b/build/upstream-builds/build-gobblin.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# This script supports:
+#
+#   Build to specific PNDA version
+#       Pass "PNDA" as first parameter
+#       Pass platform-salt branch or tag as second parameter (e.g. release/3.2)
+#   Build specific upstream version
+#       Pass "UPSTREAM" as first parameter
+#       Pass upstream branch or tag as second parameter (e.g. 1.2.3.4)
+#   Here,
+#       We clone the entire apache gobblin-incubator repository.
+#       Add the gobblin-PNDA classes from dependency classes in the apache gobblin as a module.
+#       Build the gobblin-PNDA jar along with other dependencies from the apache.
+
+MODE=${1}
+ARG=${2}
+
+EXCLUDES="-x test"
+set -e
+set -x
+
+export LC_ALL=en_US.utf8
+
+function error {
+    echo "Not Found"
+    echo "Please run the build dependency installer script"
+    exit -1
+}
+
+echo -n "Java 1.8: "
+if [[ $($JAVA_HOME/bin/javac -version 2>&1) != "javac 1.8"* ]]; then
+    error
+else
+    echo "OK"
+fi
+
+echo -n "shyaml: "
+if [[ -z $(which shyaml) ]]; then
+    error
+else
+    echo "OK"
+fi
+
+
+if [[ ${MODE} == "PNDA" ]]; then
+    GB_VERSION=$(wget -qO- https://raw.githubusercontent.com/pndaproject/platform-salt/${ARG}/pillar/services.sls | shyaml get-value gobblin.release_version)
+
+elif [[ ${MODE} == "UPSTREAM" ]]; then
+    GB_VERSION=${ARG}
+fi
+
+wget https://github.com/apache/incubator-gobblin/archive/gobblin_${GB_VERSION}.tar.gz
+tar xzf gobblin_${GB_VERSION}.tar.gz
+
+# Build upstream gobblin
+mkdir -p pnda-build
+
+cd incubator-gobblin-gobblin_${GB_VERSION}
+if ! fgrep -q 'tasks.withType(Javadoc).all { enabled = false }' build.gradle; then
+cat >> build.gradle << EOF
+subprojects {
+  tasks.withType(Javadoc).all { enabled = false }
+}
+EOF
+fi
+
+# Add HDP Repositories to the gradle.
+line_number=$(grep -n "repository.cloudera.com" defaultEnvironment.gradle |cut -f1 -d:)
+line_number=$((line_number+2))
+hdp_repo_1='\tmaven {\n\turl "http://repo.hortonworks.com/content/repositories/releases/"\n\t}'
+hdp_repo_2='\tmaven {\n\turl "http://repo.hortonworks.com/content/repositories/jetty-hadoop/"\n\t}'
+sed -i "$line_number"'i\'"$hdp_repo_1"'\n'"$hdp_repo_2" defaultEnvironment.gradle
+
+for HADOOP_DISTRIBUTION in CDH HDP
+do
+    if [[ "${HADOOP_DISTRIBUTION}" == "CDH" ]]; then
+        HADOOP_VERSION=2.6.0-cdh5.9.0
+    fi
+    if [[ "${HADOOP_DISTRIBUTION}" == "HDP" ]]; then
+        HADOOP_VERSION=2.7.3.2.6.3.0-235
+    fi
+
+    ./gradlew build -Pversion="${GB_VERSION}-${HADOOP_DISTRIBUTION}" -PhadoopVersion="${HADOOP_VERSION}" -PexcludeHadoopDeps -PexcludeHiveDeps ${EXCLUDES}
+
+    mv ./build/gobblin-distribution/distributions/gobblin-distribution-${GB_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz ../pnda-build/
+    sha512sum ../pnda-build/gobblin-distribution-${GB_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz > ../pnda-build/gobblin-distribution-${GB_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz.sha512.txt
+
+done


### PR DESCRIPTION
# Problem Statement:
PNDA-3133: Remove Gobblin fork and use release distribution instead.

# Analysis:
Currently, gobblin is not a upstream project.
We need to build the gobblin components as upstream components except the pnda-gobblin modules .

# Change:
- Changed the gobblin as a upsteam build project.
- Added the gobblin build script which builds gobblin as upstream project.
- Gobblin is built separately for CDH and HDP distibutions for below Hadoop Versions -
  CDH - 2.6.0-cdh5.9.0
  HDP - 2.7.3.2.6.3.0-235

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification pending for OpenStack.