### PR TITLE
Make install script use JAVA_MIRROR if defined

### DIFF
--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -58,7 +58,7 @@ echo "Dependency check: Java JDK 1.8.0_131"
 
 if [[ $($JAVA_HOME/bin/javac -version 2>&1) != "javac 1.8.0_131" ]]; then
     echo "WARN: Unable to find JDK 1.8.0_131, going to download it and set JAVA_HOME relative to ${PWD}"
-    curl -LOJ -b oraclelicense=accept-securebackup-cookie -L http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
+    curl -LOJ -b oraclelicense=accept-securebackup-cookie "${JAVA_MIRROR:-http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz}"
     tar zxf jdk-8u131-linux-x64.tar.gz --no-same-owner
     export JAVA_HOME=${PWD}/jdk1.8.0_131
     export PATH=$JAVA_HOME/bin:${PATH}


### PR DESCRIPTION
If JAVA_MIRROR environment variable is set, the specified mirror will be used.

Otherwise, will keep downloading from the hardcoded oracle URL.