### PR TITLE
Expand environment variables in all mirror scripts

### DIFF
--- a/mirror/create_mirror_apps.sh
+++ b/mirror/create_mirror_apps.sh
@@ -7,7 +7,7 @@ STATIC_FILE_DIR=$MIRROR_OUTPUT_DIR/mirror_apps
 mkdir -p $STATIC_FILE_DIR
 cd $STATIC_FILE_DIR
 
-STATIC_FILE_LIST_APP=$(<${MIRROR_BUILD_DIR}/dependencies/pnda-static-file-app-dependencies.txt)
+STATIC_FILE_LIST_APP=$(envsubst < ${MIRROR_BUILD_DIR}/dependencies/pnda-static-file-app-dependencies.txt)
 cd $STATIC_FILE_DIR
 echo "$STATIC_FILE_LIST_APP" | while read STATIC_FILE
 do

--- a/mirror/tools/python_download_packages.py
+++ b/mirror/tools/python_download_packages.py
@@ -5,11 +5,11 @@ Download python packages based on requirement files
 import re
 import time
 import os
+import string
 import subprocess
 import sys
 
 def main():
-
     package_path=os.environ['MIRROR_OUTPUT_DIR']+"/mirror_python/packages"
     requirements_path=os.environ['PYTHON_REQ_DIR']
     file_py2 = open(requirements_path+"/pnda_requirements_py2.txt","r") 
@@ -20,7 +20,7 @@ def main():
 
     # download python 2 libs
     subprocess.call(["pip2","download","setuptools","--platform","multilinux1_x86_64","--python-version","27","--implementation","py","--only-binary=:all:","-d",package_path])
-    python_deps = (file_py2.read()).rstrip().split('\n')
+    python_deps = string.Template((file_py2.read()).rstrip()).safe_substitute(os.environ).split('\n')
     for one_dep in python_deps:
         ret_code = subprocess.call(["pip2","download", "--no-deps", one_dep,"--no-binary",":all:","-d",package_path])
         if ret_code != 0:
@@ -28,7 +28,7 @@ def main():
 
     # download python 3 libs
     subprocess.call(["pip3","download","setuptools","--only-binary=:all:","-d",package_path])
-    python_deps = (file_py3.read()).rstrip().split('\n')
+    python_deps = string.Template((file_py3.read()).rstrip()).safe_substitute(os.environ).split('\n')
     for one_dep in python_deps:
         ret_code = subprocess.call(["pip3","download", "--no-deps", one_dep,"-d",package_path])
         if ret_code != 0:


### PR DESCRIPTION
For consistent behaviour in all mirror scripts:
 - Add missing envsubst to create_mirror_apps.sh
 - Expand variables in create_mirror_python.sh

PNDA-4401