### PR TITLE
PNDA-4608: Mismatch setuptools version in mirror and build

### DIFF
--- a/mirror/create_mirror_python.sh
+++ b/mirror/create_mirror_python.sh
@@ -17,10 +17,10 @@ fi
 
 curl -LOJf https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
-pip2 install setuptools==34.2.0
+pip2 install --upgrade setuptools
 pip2 install github3.py
 python3 get-pip.py
-pip3 install setuptools==34.2.0
+pip3 install --upgrade setuptools
 rm get-pip.py
 
 python $MIRROR_BUILD_DIR/tools/python_download_packages.py

--- a/mirror/dependencies/pnda_requirements_py2.txt
+++ b/mirror/dependencies/pnda_requirements_py2.txt
@@ -96,7 +96,6 @@ requests==2.12.4
 requests_kerberos==0.11.0
 rfc3986==0.4.1
 sasl==0.2.1
-setuptools==34.3.3
 simplejson==3.10.0
 singledispatch==3.4.0.3
 six==1.10.0


### PR DESCRIPTION
PNDA-4608

Analysis: 
Setuptools version used in script 'create_mirror_python.sh' is 34.2.0 and in build is latest version i,e 39.1.0.

Solution:
1) Modified pip2 install setuptools==34.2.0 to pip2 install --upgrade setuptools. 
2) Modified pip3 install setuptools==34.2.0 to pip3 install --upgrade setuptools. 
2) Removed setuptools==34.3.3 from dependencies/pnda_requirements_py2.txt.

Files modified
mirror/create_mirror_python.sh
 mirror/dependencies/pnda_requirements_py2.txt

Tested on RHEL.