### PR TITLE
PNDA-4622: CentOS Mirror Fail

### DIFF
--- a/mirror/dependencies/pnda-rpm-package-dependencies-centos.txt
+++ b/mirror/dependencies/pnda-rpm-package-dependencies-centos.txt
@@ -38,9 +38,9 @@ nginx
 nmap-ncat
 ntp-4.2.6p5
 patch
-openssl-1.0.2k-8.el7
-openssl-libs-1.0.2k-8.el7
-openssl-devel-1.0.2k-8.el7
+openssl-1.0.2k-12.el7
+openssl-libs-1.0.2k-12.el7
+openssl-devel-1.0.2k-12.el7
 pam-devel
 policycoreutils-python
 postgresql-devel


### PR DESCRIPTION
Analysis:
Script create_mirror_rpm.sh fails with below issue.
No Match for argument  openssl-1.0.2k-8.el7 available.
No Match for argument  openssl-libs-1.0.2k-8.el7 available.
No Match for argument  openssl-devel-1.0.2k-8.el7 available.

Openssl version used in mirror is openssl-1.0.2k-8.el7, But latest available version is openssl-1.0.2k-12.el7.

Solution:
Changed to latest version for all the three openssl related packages as below.
openssl-1.0.2k-12.el7
openssl-libs-1.0.2k-12.el7
openssl-devel-1.0.2k-12.el7

Files modified:
mirror/dependencies/pnda-rpm-package-dependencies-centos.txt

Tested:
Release 4.0:
  Centos 7.4 HDP pico
Develop:
  Centos 7.4 HDP pico 
  Centos 7.5 HDP pico 