### PR TITLE
PNDA-4630 Build hung while during kafkamanager

### DIFF
--- a/build/upstream-builds/build-kafkamanager.sh
+++ b/build/upstream-builds/build-kafkamanager.sh
@@ -53,7 +53,7 @@ ATTEMPT=0
 RETRY=3
 until [[ ${ATTEMPT} -ge ${RETRY} ]]
 do
-    sbt clean dist < /dev/null && break
+    setsid sbt clean dist < /dev/null && break
     ATTEMPT=$[${ATTEMPT}+1]
     sleep 1
 done


### PR DESCRIPTION
Analysis:
"sbt" command hangs in interactive mode

Solution:
Handle"sbt" command via "setsid"
"setsid" - creates a session and sets the process group ID

Tested in both interactive and non-interactive mode.