### PR TITLE
PNDA-4706 Ubuntu Build: mock package fails to install

### DIFF
--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -179,6 +179,7 @@ curl -LOJf https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 pip2 install --upgrade setuptools
 
+pip2 install six==1.10.0 --ignore-installed
 pip2 install spur==0.3.12
 pip2 install starbase==0.3.2
 pip2 install happybase==1.0.0


### PR DESCRIPTION
Analysis:
For Ubuntu, mock package requires six (>=1.9), But dist-utils unable to upgrade six package.

Solution:
Upgraded six version to 1.10.0 as below.
pip2 install six==1.10.0 --ignore-installed

Files modified:
build/install-build-tools.sh

Tested:
Verified mirror & build on Ubuntu, Centos and Rhel with 1.1.1 branch.