### PR TITLE
PNDA-4707 HDP Cluster creation fails with Ubuntu in AWS

### DIFF
--- a/mirror/create_mirror_hdp.sh
+++ b/mirror/create_mirror_hdp.sh
@@ -39,6 +39,8 @@ rm -rf HDP-UTILS
 tar zxf HDP-UTILS-1.1.0.22-centos7.tar.gz
 mkdir -p HDP-UTILS-1.1.0.22/repos/
 mv HDP-UTILS/centos7/1.1.0.22 HDP-UTILS-1.1.0.22/repos/centos7
+mkdir HDP-UTILS-1.1.0.22/repos/ubuntu14/dists/HDP-UTILS
+cp -R HDP/ubuntu14/2.6.4.0-91/dists/HDP/* HDP-UTILS-1.1.0.22/repos/ubuntu14/dists/HDP-UTILS/
 rm -rf HDP-UTILS
 
 rm -f HDP-2.6.4.0-centos7-rpm.tar.gz


### PR DESCRIPTION
Analysis:

HDP cluster creation is failing with Ubuntu in AWS. 
It's failed to get a package from repo during Hadoop (App Timeline Server) install.

HDP-Utils tar not bundled with dists packages, dists folder is empty ("HDP-UTILS/ubuntu14/1.1.0.22/dists/").
Missing HDP-utils dists files are available in HDP tar file ("HDP/ubuntu14/2.6.4.0-91/dists/HDP/")

Solution:
Created HDP-UTILS directory in dists directory (HDP-UTILS-1.1.0.22/repos/ubuntu14/dists)
Copied all files from HDP path("HDP/ubuntu14/2.6.4.0-91/dists/HDP/") to created HDP-UTILS directory.

Files changed- 
pnda/mirror/create_mirror_hdp.sh

Tested:
AWS-PICO-HDP-UBUNTU
AWS-STANDARD-HDP-UBUNTU