### PR TITLE
PNDA-4440: Upgrade kafka from 0.11.0.2 to 1.1.0

### DIFF
--- a/mirror/dependencies/pnda-static-file-dependencies.txt
+++ b/mirror/dependencies/pnda-static-file-dependencies.txt
@@ -2,7 +2,7 @@ http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096f
 http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.25/mysql-connector-java-5.1.25.jar
 http://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
 http://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz.sha1
-http://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz
+http://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz
 https://artifacts.elastic.co/downloads/logstash/logstash-${LOGSTASH_VERSION}.tar.gz
 https://artifacts.elastic.co/downloads/logstash/logstash-${LOGSTASH_VERSION}.tar.gz.sha512
 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${LOGSTASH_VERSION}.tar.gz


### PR DESCRIPTION
Problem Statement:
Upgrade Kafka from 0.11.0.2 to 1.1.0

Analysis:
Kafka source is added to mirror as part of mirror_misc. So new download link needs to be provided.

Changes Done:
Provided 1.1.0 download link in dependency file.