### PR TITLE
PNDA-4837: Upgrade Grafana version to 5.1.3

### DIFF
--- a/mirror/dependencies/pnda-static-file-dependencies.txt
+++ b/mirror/dependencies/pnda-static-file-dependencies.txt
@@ -14,7 +14,7 @@ https://github.com/klyr/jupyter-spark/releases/download/0.3.0-patch/jupyter-spar
 https://github.com/mk23/jmxproxy/releases/download/jmxproxy.3.2.0/jmxproxy-3.2.0.jar
 https://nodejs.org/download/release/v6.10.2/SHASUMS256.txt
 https://nodejs.org/download/release/v6.10.2/node-v6.10.2-linux-x64.tar.gz
-https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.2.0-1.x86_64.rpm
+https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.3-1.x86_64.rpm
 http://central.maven.org/maven2/com/sleepycat/je/5.0.73/je-5.0.73.jar
 https://repo.continuum.io/archive/Anaconda2-${ANACONDA_VERSION}-Linux-x86_64.sh
 http://central.maven.org/maven2/org/kitesdk/kite-tools/1.0.0/kite-tools-1.0.0-binary.jar


### PR DESCRIPTION
**Update Grafana to latest stable release**

- Modified "pnda-static-file-dependencies.txt" with latest Grafana version 5.1.3


