### PR TITLE
PDNA-ENV: Explicit pathing

### DIFF
--- a/packer/scripts/build.sh
+++ b/packer/scripts/build.sh
@@ -27,7 +27,7 @@ EOF
 [[ $? -ne 0 ]] && mirror_error "Problem while installing build tools"
 
 # Build PNDA software
-source set-pnda-env.sh
+source ${PWD}/set-pnda-env.sh
 cd pnda/build
 ./build-pnda.sh $BUILD_MODE $BUILD_ARG << EOF
 Yes


### PR DESCRIPTION
In prep for using Docker, we need to be more explicit on our path for set-pnda-env.sh.