### PR TITLE
Revert "Stops install-build-tools.sh script on first error"

### DIFF
--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -16,7 +16,6 @@
 #   This script checks for and installs dependencies required to build PNDA
 #
 #   JAVA_MIRROR - define this environment variable to download the Java JDK from an alternative location
-set -e
 
 SPARK_VERSION='1.6.0'
 


### PR DESCRIPTION
This reverts commit 358a4ee928d3a281b5310710c5e08c9d5282af23.

The yum tools return non-zero if there's nothing to do, which isn't an error, yet will cause this script to fail with set -e. In general we should prefer explicit error checking to the blanket behaviour of set -e, and at the very least any PR should improve the code _and_ keep it working