### PR TITLE
[FIX] CentOS 7 get-pip error

### DIFF
--- a/mirror/create_mirror_python.sh
+++ b/mirror/create_mirror_python.sh
@@ -19,7 +19,6 @@ curl -sS -LOJf https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 pip2 install setuptools==39.1.0
 pip2 install github3.py==1.1.0
-python3.4 get-pip.py
 pip3.4 install setuptools==39.1.0
 rm get-pip.py
 


### PR DESCRIPTION
get-pip.py requires Python 3.5+, and pip3.4 already installed on line 11